### PR TITLE
adds .env parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"net/http"
 	"fmt"
+	"log"
+	"os"
+	"github.com/subosito/gotenv"
 )
 
 func main() {
+	gotenv.Load(".env")
+
 	http.HandleFunc("/", HelloWorldHandler)
 
 	fmt.Println("Listening on localhost:8080")


### PR DESCRIPTION
required: creating a .env file with:
```
DB_HOST="127.0.0.1"
DB_NAME="goodbois"
DB_USER="gbuser"
DB_PASS="gbpass"
```

you can access what's in the .env file by using:
```
log.Println(os.Getenv("DB_HOST"))
```